### PR TITLE
Adding Cost calculator

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,9 @@ import fetchData from "./api/times";
 const minute = 1000 * 60;
 const hour = 60 * minute;
 const day = 24 * hour;
+function formatNumber(num) {
+  return num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')
+}
 
 export default function Home(props) {
   const { articles } = props;
@@ -20,6 +23,8 @@ export default function Home(props) {
   const hours = Math.floor((diff - days * day) / hour);
   const minutes = Math.floor((diff - days * day - hours * hour) / minute);
   const durationText = `It's been like this for ${days} days, ${hours} hours and ${minutes} minutes.`;
+  const hoursConversion = Math.floor(((days * 24) + hours + (minutes / 60))* 400000000); //https://www.cnbc.com/2021/03/25/suez-canal-blockage-is-delaying-an-estimated-400-million-an-hour-in-goods.html
+  const costText = `Total Estimated Lost Cost: $${formatNumber(hoursConversion)} dollars`;
 
   return (
     <div className={styles.container}>
@@ -64,12 +69,15 @@ export default function Home(props) {
           </a>
         </p>
         <p>{durationText}</p>
+        <p>{costText}</p>
+
+
 
         <div style={{ width: "100%", maxWidth: 600 }}>
           <div
             dangerouslySetInnerHTML={{
               __html: `<script type="text/javascript">
-  var width="100%";var height="400";var zoom="14"; 
+  var width="100%";var height="400";var zoom="14";
   var mmsi=353136000;
 </script><script type="text/javascript" src="https://www.vesselfinder.com/aismap.js"></script>`,
             }}


### PR DESCRIPTION
Adding a cost calculator to calculate the estimated $ lost, using an estimate from CNBC: https://www.cnbc.com/2021/03/25/suez-canal-blockage-is-delaying-an-estimated-400-million-an-hour-in-goods.html

I'm just taking the total time of the ship being stuck, converting to hours and multiplying by $400M.